### PR TITLE
adjust relative paths for font declarations

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2,11 +2,11 @@
 @import url("https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,400italic");
 @font-face {
 	font-family: "Hickory Jack";
-	src: url("assets/webfonts/Hickory Jack.woff") format('woff');
+	src: url("../webfonts/Hickory Jack.woff") format('woff');
 }
 @font-face {
 	font-family: "NovitoNova-Regular";
-	src: url("assets/webfonts/NovitoNova-Regular.woff") format('woff');	
+	src: url("../webfonts/NovitoNova-Regular.woff") format('woff');	
 }
 
 /*


### PR DESCRIPTION
Since `/css` and `/webfonts` are folders at the same level, to reference a file in the other one you have to traverse down first (`../`) to get the proper reference.